### PR TITLE
Use project.version expression to get version from pom.xml

### DIFF
--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -57,7 +57,7 @@ jobs:
         id: mc_version
         run: |
           if [ -z "${{ env.MC_VERSION }}" ]; then
-            MC_VERSION=$(mvn help:evaluate -Dexpression=hazelcast.mc.version -q -DforceStdout)
+            MC_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           fi
           echo "MC_VERSION=$MC_VERSION" >> $GITHUB_ENV
           echo ::set-output name=mc_version::$MC_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast-command-line</artifactId>
+    <artifactId>management-center-packaging</artifactId>
     <version>5.2-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hazelcast.mc.version>5.2-SNAPSHOT</hazelcast.mc.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This way we can remove the property and the version needs to be updated
in single place only, which is less errorprone and easier to script in
Hazelcast release pipeline.

See https://github.com/hazelcast/hazelcast-packaging/pull/132