### PR TITLE
Use headless Java as dependency for deb and rpm packages

### DIFF
--- a/packages/deb/hazelcast-management-center/DEBIAN/control
+++ b/packages/deb/hazelcast-management-center/DEBIAN/control
@@ -4,7 +4,7 @@ Version: ${PACKAGE_VERSION}
 Section: imdg
 Priority: optional
 Architecture: all
-Depends: default-jdk | java8-sdk
+Depends: default-jdk-headless | java8-sdk-headless
 Maintainer: Hazelcast Platform Team <platform@hazelcast.com>
 Description: Hazelcast Management Center enables monitoring and management of nodes running Hazelcast.
 Homepage: https://www.hazelcast.com/

--- a/packages/rpm/hazelcast-management-center.spec
+++ b/packages/rpm/hazelcast-management-center.spec
@@ -18,7 +18,7 @@ Source1:    hazelcast-management-center.service
 
 Requires(pre): shadow-utils
 
-Requires:	java
+Requires:	java-headless
 
 BuildArch:  noarch
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
This will save users time to download and some space locally.

I have check distribution packages in Ubuntu and RHEL and commonly
available Java packages from:

- Adoptopendk
- Temurin
- Oracle

and they all provide the correct meta package (deb) or capability (rpm).

See https://github.com/hazelcast/hazelcast-packaging/pull/133