### PR TITLE
Update `#!/usr/bin/env bash` references to `#!/bin/bash` [DI-216]

### DIFF
--- a/build-mc-deb-package.sh
+++ b/build-mc-deb-package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -x
 

--- a/build-mc-homebrew-package.sh
+++ b/build-mc-homebrew-package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 if [ -z "${MC_VERSION}" ]; then
   echo "Variable MC_VERSION is not set. This is the version of Hazelcast Management Center used to build the package."

--- a/build-mc-rpm-package.sh
+++ b/build-mc-rpm-package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -x
 

--- a/check-mc-health.sh
+++ b/check-mc-health.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 attempts=0
 max_attempts=30

--- a/packages/brew/functions.sh
+++ b/packages/brew/functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function alphanumCamelCase {
   echo "$1"|  sed -r 's/(-)/\./g' | tr '[:upper:]' '[:lower:]' | sed "s/\b\(.\)/\u\1/g" | sed 's+\.++g'

--- a/packages/brew/test_brew_functions.sh
+++ b/packages/brew/test_brew_functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD

--- a/test_common.sh
+++ b/test_common.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD


### PR DESCRIPTION
We _mostly_ use `#!/bin/bash` ([~700 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fbin%2Fbash%22&type=code)), but sometimes we use `#!/usr/bin/env bash` ([~500 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fusr%2Fbin%2Fenv+bash%22&type=code)).

We should be consistent.

Of note - [Google's style guide](https://google.github.io/styleguide/shellguide.html) suggests the same.

Fixes: [DI-216](https://hazelcast.atlassian.net/browse/DI-216)

[DI-216]: https://hazelcast.atlassian.net/browse/DI-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ