### PR TITLE
Migrate GitHub runners to Ubicloud [DI-273]

### DIFF
--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -45,7 +45,7 @@ concurrency: single-build
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     env:
       MC_VERSION: ${{ inputs.MC_VERSION }}
     defaults:
@@ -91,7 +91,7 @@ jobs:
           echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
   deb:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: ${{ needs.prepare.outputs.package_types == 'all' || needs.prepare.outputs.package_types == 'deb' }}
     env:
       MC_VERSION: ${{ needs.prepare.outputs.mc_version }}
@@ -161,7 +161,7 @@ jobs:
             "$DEBIAN_REPO_BASE_URL/hazelcast-management-center-${DEB_PACKAGE_VERSION}-all.deb"
 
   rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: ${{ needs.prepare.outputs.package_types == 'all' || needs.prepare.outputs.package_types == 'rpm' }}
     container: rockylinux:9
     env:


### PR DESCRIPTION
T[o reduce GitHub Actions costs, migrate GitHub runners to Ubicloud](https://hazelcast.atlassian.net/browse/DI-268).

Fixes: [DI-273](https://hazelcast.atlassian.net/browse/DI-273)

[DI-273]: https://hazelcast.atlassian.net/browse/DI-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ