### PR TITLE
Stop PR builder running when PR is edited

### DIFF
--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -11,7 +11,6 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [ opened, synchronize, edited ]
   workflow_dispatch:
     inputs:
       MC_VERSION:


### PR DESCRIPTION
The PR builder runs whenever the text of a PR is edited, which is inefficient and not consistent with how other projects are configured.

Related - https://github.com/hazelcast/hazelcast-packaging/pull/242