### PR TITLE
Refactor how `assert.sh` is downloaded for tests

### DIFF
--- a/packages/brew/test_brew_functions.sh
+++ b/packages/brew/test_brew_functions.sh
@@ -22,13 +22,7 @@ function findScriptDir() {
 }
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
-
-# shellcheck source=/dev/null
-# You _should_ be able to avoid a temporary file with something like
-# . <(echo "${assert_script_content}")
-# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
-. assert.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 findScriptDir
 

--- a/test_common.sh
+++ b/test_common.sh
@@ -22,13 +22,7 @@ function findScriptDir() {
 }
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
-
-# shellcheck source=/dev/null
-# You _should_ be able to avoid a temporary file with something like
-# . <(echo "${assert_script_content}")
-# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
-. assert.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 findScriptDir
 


### PR DESCRIPTION
We can simplify as discussed [here](https://github.com/hazelcast/docker-actions/pull/1#discussion_r2149451062).