### PR TITLE
Fix Debian `Warning: apt-key is deprecated` installation warning

### DIFF
--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           source ./common.sh
           wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+          echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
           sudo apt update && sudo apt install hazelcast-management-center=${MC_VERSION}
           /usr/lib/hazelcast-management-center/bin/hz-mc start -Dhazelcast.mc.healthCheck.enable=true > hz-mc.log 2>&1 &
 

--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -137,8 +137,8 @@ jobs:
       - name: Install Hazelcast Management Center from DEB
         run: |
           source ./common.sh
-          wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-          echo "deb ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
+          wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
           sudo apt update && sudo apt install hazelcast-management-center=${MC_VERSION}
           /usr/lib/hazelcast-management-center/bin/hz-mc start -Dhazelcast.mc.healthCheck.enable=true > hz-mc.log 2>&1 &
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ You can find the Debian packages for Hazelcast Management Center at
 Run the following commands to install the package using apt:
 
 ```
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast-management-center
 ```
 
@@ -125,8 +125,8 @@ repository definition to use Hazelcast Management Center snapshots.
 Run the following to install the latest snapshot version:
 
 ```
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast-management-center
 ```
 


### PR DESCRIPTION
Copies the fix from platform added in https://github.com/hazelcast/hazelcast-packaging/pull/143.

Error logged [here](https://github.com/hazelcast/management-center-packaging/actions/runs/15684079799/job/44182664757).

Tested locally:
> Hazelcast Management Center has been successfully installed to '/usr/lib/hazelcast-management-center/'
Use 'hz-mc start' or 'systemctl start hazelcast-management-center' to start the Hazelcast Management Center server
