### PR TITLE
Update `SNAPSHOT` version to `6.0` in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>management-center-packaging</artifactId>
-    <version>5.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 


### PR DESCRIPTION
The `RPM` PR test [is failing](https://github.com/hazelcast/management-center-packaging/actions/runs/15685687590/job/44188160384) because it's downloading `6.0` but hardcoded to expect `5.4`.