### PR TITLE
Stop creation of `pom.xml.versionsBackup` files

### DIFF
--- a/.github/workflows/tag-branch.yml
+++ b/.github/workflows/tag-branch.yml
@@ -35,6 +35,7 @@ jobs:
           mvn versions:set \
             --batch-mode \
             --no-transfer-progress \
+            -DgenerateBackupPoms=false \
             -DnewVersion=${{ steps.version.outputs.inc-patch }}
 
       - name: Configure git


### PR DESCRIPTION
[`versions:set` leaves a backup behind](https://www.mojohaus.org/versions/versions-maven-plugin/set-mojo.html#generateBackupPoms) which is unnecessary.

See https://github.com/hazelcast/management-center-packaging/commit/d5123e03212cc7bc284993f8fbd152533e10f8c9