### PR TITLE
Maven 4 compatibility - use `--raw-streams` option with `help:evaluate` [DI-736]

### DIFF
--- a/.github/workflows/publish-mc-packages.yml
+++ b/.github/workflows/publish-mc-packages.yml
@@ -58,7 +58,7 @@ jobs:
         id: mc_version
         run: |
           if [ -z "${{ env.MC_VERSION }}" ]; then
-            MC_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            MC_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --raw-streams)
           fi
           echo "MC_VERSION=$MC_VERSION" >> $GITHUB_ENV
           echo "mc_version=$MC_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag-branch.yml
+++ b/.github/workflows/tag-branch.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get current project version
         id: project-version
         run: |
-          echo "MC_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> ${GITHUB_OUTPUT}
+          echo "MC_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --raw-streams)" >> ${GITHUB_OUTPUT}
 
       - uses: madhead/semver-utils@latest
         id: version


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-mono/pull/5980

Although not using Maven wrapper, we can still be confident the version of Maven is suitable for this option as `ubuntu-latest` runner image includes:
https://github.com/actions/runner-images/blob/d6a1c18e53c5df0ef89efeef6b97d814de3eae28/images/ubuntu/Ubuntu2404-Readme.md#L60

Fixes: [DI-736](https://hazelcast.atlassian.net/browse/DI-736)

[DI-736]: https://hazelcast.atlassian.net/browse/DI-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ