### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/packages/brew/test_brew_functions.sh
+++ b/packages/brew/test_brew_functions.sh
@@ -22,7 +22,7 @@ function findScriptDir() {
 }
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 findScriptDir
 

--- a/test_common.sh
+++ b/test_common.sh
@@ -22,7 +22,7 @@ function findScriptDir() {
 }
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 findScriptDir
 


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.